### PR TITLE
Automatically creating CODEOWNERS file [Skip CI]

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Guessed from teams who have admin access in github
+* @Financial-Times/cloud-enablement


### PR DESCRIPTION
Created by https://github.com/Financial-Times/codeowners-creation